### PR TITLE
Add eslint-plugin-moment-utc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ node_js:
 - node
 test:
 - yarn check
-- npm run checkPeerDependencies
-- npm test
+- yarn checkPeerDependencies
+- yarn test
 cache: yarn
 deploy:
   provider: npm

--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@ module.exports = {
 - https://github.com/xjamundx/eslint-plugin-promise
 - https://github.com/yannickcr/eslint-plugin-react
 - https://github.com/intellicode/eslint-plugin-react-native
+- https://github.com/babel/babel-eslint

--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@ module.exports = {
 - https://github.com/xjamundx/eslint-plugin-promise
 - https://github.com/yannickcr/eslint-plugin-react
 - https://github.com/intellicode/eslint-plugin-react-native
+- https://github.com/wunderflats/eslint-plugin-moment-utc

--- a/eslint.js
+++ b/eslint.js
@@ -43,6 +43,7 @@ module.exports = {
         'import',
         'promise',
         'eslint-comments',
+        'babel',
     ],
     settings: {
         'import/ignore': [
@@ -118,7 +119,7 @@ module.exports = {
         'no-floating-decimal': 'error',
         'no-implicit-coercion': 'error',
         'no-implied-eval': 'error',
-        'no-invalid-this': 'error',
+        'no-invalid-this': 'off', // covered by babel/no-invalid-this
         'no-iterator': 'error',
         'no-labels': ['error', {
             allowLoop: true,
@@ -394,5 +395,9 @@ module.exports = {
         'eslint-comments/no-unused-disable': 'error',
         'eslint-comments/no-unused-enable': 'error',
         'eslint-comments/no-use': 'off',
+
+        // eslint babel
+        'babel/no-invalid-this': 'error',
+        'babel/no-await-in-loop': 'error',
     },
 }

--- a/eslint.js
+++ b/eslint.js
@@ -44,6 +44,7 @@ module.exports = {
         'promise',
         'eslint-comments',
         'babel',
+        'moment-utc',
     ],
     settings: {
         'import/ignore': [
@@ -399,5 +400,8 @@ module.exports = {
         // eslint babel
         'babel/no-invalid-this': 'error',
         'babel/no-await-in-loop': 'error',
+
+        // eslint moment utc
+        'moment-utc/no-moment-without-utc': 'error',
     },
 }

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,6 +1,10 @@
 /* @flow */
 /* eslint-disable no-unused-vars */
 
+// Imports
+
+import moment from 'moment'
+
 // Function spacing
 
 const add = (a: number, b: number): number => a + b
@@ -37,5 +41,9 @@ class Hello {
         this.bar = 1
     }
 }
+
+// Moment
+
+moment.utc()
 
 /* eslint-enable no-unused-vars */

--- a/examples/index.js
+++ b/examples/index.js
@@ -29,4 +29,13 @@ addAsync(
     2,
 )
 
+// Classes
+
+class Hello {
+    static foo = () => 1
+    bar = () => {
+        this.bar = 1
+    }
+}
+
 /* eslint-enable no-unused-vars */

--- a/package.json
+++ b/package.json
@@ -41,12 +41,13 @@
   },
   "peerDependencies": {
     "babel-eslint": "^7.1.1",
-    "eslint": "^3.11.1",
+    "eslint": "^3.12.1",
+    "eslint-plugin-babel": "^4.0.0",
     "eslint-plugin-eslint-comments": "^1.0.0",
-    "eslint-plugin-flowtype": "^2.28.2",
+    "eslint-plugin-flowtype": "^2.29.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-promise": "^3.4.0",
-    "eslint-plugin-react": "^6.7.1",
-    "eslint-plugin-react-native": "^2.2.0"
+    "eslint-plugin-react": "^6.8.0",
+    "eslint-plugin-react-native": "^2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
     "eslint-plugin-eslint-comments": "^1.0.0",
     "eslint-plugin-flowtype": "^2.29.1",
     "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-moment-utc": "^1.0.0",
     "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-react": "^6.8.0",
     "eslint-plugin-react-native": "^2.2.1",
+    "moment": "^2.17.1",
     "react": "^15.4.1"
   },
   "peerDependencies": {
@@ -46,6 +48,7 @@
     "eslint-plugin-eslint-comments": "^1.0.0",
     "eslint-plugin-flowtype": "^2.29.1",
     "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-moment-utc": "^1.0.0",
     "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-react": "^6.8.0",
     "eslint-plugin-react-native": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -29,13 +29,14 @@
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",
-    "eslint": "^3.11.1",
+    "eslint": "^3.12.1",
+    "eslint-plugin-babel": "^4.0.0",
     "eslint-plugin-eslint-comments": "^1.0.0",
-    "eslint-plugin-flowtype": "^2.28.2",
+    "eslint-plugin-flowtype": "^2.29.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-promise": "^3.4.0",
-    "eslint-plugin-react": "^6.7.1",
-    "eslint-plugin-react-native": "^2.2.0",
+    "eslint-plugin-react": "^6.8.0",
+    "eslint-plugin-react-native": "^2.2.1",
     "react": "^15.4.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -329,15 +329,19 @@ eslint-module-utils@^2.0.0:
     debug "2.2.0"
     pkg-dir "^1.0.0"
 
+eslint-plugin-babel@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-4.0.0.tgz#a92114e2c493ac3034b030d7ecf96e174a76ef3f"
+
 eslint-plugin-eslint-comments@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-1.0.0.tgz#e36743d1b2c9389e6d484846a5b46d9ade36d69e"
   dependencies:
     escape-string-regexp "^1.0.5"
 
-eslint-plugin-flowtype@^2.28.2:
-  version "2.28.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.28.2.tgz#2430ac1bf434db878e16cfde454f64b13896317b"
+eslint-plugin-flowtype@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.29.1.tgz#74cc5603ff0baff6e224482bbd17406b0980f6c3"
   dependencies:
     lodash "^4.15.0"
 
@@ -360,23 +364,23 @@ eslint-plugin-promise@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.4.0.tgz#6ba9048c2df57be77d036e0c68918bc9b4fc4195"
 
-eslint-plugin-react-native@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-native/-/eslint-plugin-react-native-2.2.0.tgz#f10a8821b2f214d7820b303af9c69597c925183a"
+eslint-plugin-react-native@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-native/-/eslint-plugin-react-native-2.2.1.tgz#9da90b76b234e6a71b06e2b9466b76f9017c16e0"
   dependencies:
     babel-eslint "7.1.1"
-    eslint "3.11.0"
+    eslint "3.12.0"
 
-eslint-plugin-react@^6.7.1:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.7.1.tgz#1af96aea545856825157d97c1b50d5a8fb64a5a7"
+eslint-plugin-react@^6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.8.0.tgz#741ab5438a094532e5ce1bbb935d6832356f492d"
   dependencies:
     doctrine "^1.2.2"
-    jsx-ast-utils "^1.3.3"
+    jsx-ast-utils "^1.3.4"
 
-eslint@3.11.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.11.0.tgz#41d34f8b3e69949beee5c097ff4e75ad13ba2d00"
+eslint@3.12.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.12.0.tgz#1dfa4ef0082e35feed90a0fb1f7996d1d426b249"
   dependencies:
     babel-code-frame "^6.16.0"
     chalk "^1.1.3"
@@ -389,7 +393,7 @@ eslint@3.11.0:
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
     glob "^7.0.3"
-    globals "^9.2.0"
+    globals "^9.14.0"
     ignore "^3.2.0"
     imurmurhash "^0.1.4"
     inquirer "^0.12.0"
@@ -413,9 +417,9 @@ eslint@3.11.0:
     text-table "~0.2.0"
     user-home "^2.0.0"
 
-eslint@^3.11.1:
-  version "3.11.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.11.1.tgz#408be581041385cba947cd8d1cd2227782b55dbf"
+eslint@^3.12.1:
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.12.1.tgz#507a609fe251dfefd58fda03e6dbd7e851c07581"
   dependencies:
     babel-code-frame "^6.16.0"
     chalk "^1.1.3"
@@ -428,7 +432,7 @@ eslint@^3.11.1:
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
     glob "^7.0.3"
-    globals "^9.2.0"
+    globals "^9.14.0"
     ignore "^3.2.0"
     imurmurhash "^0.1.4"
     inquirer "^0.12.0"
@@ -568,9 +572,9 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.0.0, globals@^9.2.0:
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.12.0.tgz#992ce90828c3a55fa8f16fada177adb64664cf9d"
+globals@^9.0.0, globals@^9.14.0:
+  version "9.14.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-9.14.0.tgz#8859936af0038741263053b39d0e76ca241e4034"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -739,7 +743,7 @@ jsonpointer@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.0.tgz#6661e161d2fc445f19f98430231343722e1fcbd5"
 
-jsx-ast-utils@^1.3.3:
+jsx-ast-utils@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.3.4.tgz#0257ed1cc4b1e65b39d7d9940f9fb4f20f7ba0a9"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -360,6 +360,12 @@ eslint-plugin-import@^2.2.0:
     minimatch "^3.0.3"
     pkg-up "^1.0.0"
 
+eslint-plugin-moment-utc@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-moment-utc/-/eslint-plugin-moment-utc-1.0.0.tgz#d3185afa62d331c45709b3bc1743a5288de79dc2"
+  dependencies:
+    requireindex "~1.1.0"
+
 eslint-plugin-promise@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.4.0.tgz#6ba9048c2df57be77d036e0c68918bc9b4fc4195"
@@ -791,6 +797,10 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment@^2.17.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.17.1.tgz#fed9506063f36b10f066c8b59a144d7faebe1d82"
+
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
@@ -948,6 +958,10 @@ require-uncached@^1.0.2:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
 
 resolve-from@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
I can't think of many if any reasons to use moment() over moment.utc()
This makes calling moment() an error

https://www.npmjs.com/package/eslint-plugin-moment-utc