### PR TITLE
Updated peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,17 +50,17 @@
   },
   "peerDependencies": {
     "babel-eslint": "^7.2.2",
-    "eslint": "^3.19.0",
-    "eslint-plugin-babel": "^4.1.1",
-    "eslint-plugin-eslint-comments": "^1.0.0",
-    "eslint-plugin-flowtype": "^2.32.1",
-    "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jest": "^19.0.1",
-    "eslint-plugin-jsdoc": "^3.0.2",
+    "eslint": "^4.5.0",
+    "eslint-plugin-babel": "^4.1.2",
+    "eslint-plugin-eslint-comments": "^1.0.3",
+    "eslint-plugin-flowtype": "^2.35.0",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jest": "^20.0.3",
+    "eslint-plugin-jsdoc": "^3.1.2",
     "eslint-plugin-moment-utc": "^1.0.0",
     "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-react": "^6.10.3",
-    "eslint-plugin-react-native": "^2.3.2",
+    "eslint-plugin-react": "^7.3.0",
+    "eslint-plugin-react-native": "^3.1.0",
     "prettier": "^1.3.0"
   }
 }


### PR DESCRIPTION
# Summary

The `devDependencies` and `peerDependencies` for the eslint-config did not match. This means that we had rules that expected a certain version of a plugin to be installed but with no warning that this was required in the consuming project.