### PR TITLE
v2.4.1 (Patch Fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ RNF Digital ESLint configuration
 
 ## Install
 ```sh
-yarn add --dev @rnfdigital/eslint-config babel-eslint eslint eslint-config-prettier eslint-plugin-babel eslint-plugin-eslint-comments eslint-plugin-flowtype eslint-plugin-import eslint-plugin-jest eslint-plugin-jsdoc eslint-plugin-moment-utc eslint-plugin-prettier eslint-plugin-promise eslint-plugin-react eslint-plugin-react-native prettier
+yarn add --dev @rnfdigital/eslint-config babel-eslint eslint eslint-config-prettier eslint-plugin-babel eslint-plugin-eslint-comments eslint-plugin-flowtype eslint-plugin-import eslint-plugin-jest eslint-plugin-jsdoc eslint-plugin-moment-utc eslint-plugin-prettier eslint-plugin-promise eslint-plugin-react eslint-plugin-react-native prettier eslint-plugin-sort-imports-es6-autofix
 ```
 
 ## Setup
@@ -35,3 +35,4 @@ module.exports = {
 - https://github.com/wunderflats/eslint-plugin-moment-utc
 - https://github.com/facebook/jest/tree/master/packages/eslint-plugin-jest
 - https://github.com/prettier/eslint-plugin-prettier
+- https://github.com/marudor/eslint-plugin-sort-imports-es6-autofix

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rnfdigital/eslint-config",
   "description": "RNF Digital ESLint configuration",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/RNFDigital/eslint-config.git"

--- a/react.js
+++ b/react.js
@@ -74,7 +74,7 @@ module.exports = {
                 reservedFirst: true,
                 shorthandFirst: false,
                 shorthandLast: false,
-                ignoreCase: false,
+                ignoreCase: true,
             },
         ],
         'react/jsx-uses-react': 'error',


### PR DESCRIPTION
https://github.com/RNFDigital/projects/issues/1712
---
# v2.4.1

Changed
---
* `react/jsx-sort-props` now ignores case and just sorts props by starting letter.

This change is to keep consistency with our import sort, and also because the autofix always works as though case is ignored regardless of the setting. So with `ignoreCase: false` the autofix doesn't work.

Test Plan
---
Try the autofix with one of the example files in the config project, see if it orders things correctly. (It does.)